### PR TITLE
update-alternatives: Error: not linking /home/linux/openvision-develo…

### DIFF
--- a/meta-openvision/recipes-extended/wget/wget_1.%.bbappend
+++ b/meta-openvision/recipes-extended/wget/wget_1.%.bbappend
@@ -1,8 +1,8 @@
-inherit upx_compress
+inherit upx_compress update-alternatives
 
 DEPENDS_remove = "gnutls"
 DEPENDS_append = " openssl"
 EXTRA_OECONF_remove = "--with-ssl=gnutls"
 EXTRA_OECONF_append = " --with-ssl=openssl"
 
-ALTERNATIVE_${PN} = ""
+ALTERNATIVE_${PN} = "wget"


### PR DESCRIPTION
…pment-platform/build/tmp/work/spark7162-oe-linux/openvision-enigma2-image/1.0-r0/rootfs/usr/bin/wget to /bin/busybox.nosuid since /home/linux/openvision-development-platform/build/tmp/work/spark7162-oe-linux/openvision-enigma2-image/1.0-r0/rootfs/usr/bin/wget exists and is not a link

ERROR: openvision-enigma2-image-1.0-r0 do_rootfs: Postinstall scriptlets of ['busybox'] have failed. If the intention is to defer them to first boot,
then please place them into pkg_postinst_ontarget_${PN} ().
Deferring to first boot via 'exit 1' is no longer supported.
Details of the failure are in /home/linux/openvision-development-platform/build/tmp/work/spark7162-oe-linux/openvision-enigma2-image/1.0-r0/temp/log.do_rootfs.
ERROR: Logfile of failure stored in: /home/linux/openvision-development-platform/build/tmp/work/spark7162-oe-linux/openvision-enigma2-image/1.0-r0/temp/log.do_rootfs.23344
ERROR: Task (/home/linux/openvision-development-platform/meta-openvision/recipes-openvision/images/openvision-enigma2-image.bb:do_rootfs) failed with exit code '1'